### PR TITLE
Add task user to track which user added the task

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -51,6 +51,8 @@ var addTaskCmd = &cobra.Command{
 	Short: "This flag will add the desired task",
 	Long:  `This add flag will add the desired task in the database.`,
 	Run: func(cmd *cobra.Command, args []string) {
+		user, _ := cmd.Flags().GetString("user")
+		args = append(args, user)
 		controllers.AddTask(args)
 	},
 }
@@ -60,6 +62,8 @@ func init() {
 	rootCmd.AddCommand(addTaskCmd)
 	rootCmd.AddCommand(updateTaskCmd)
 	rootCmd.AddCommand(deleteTaskCmd)
+
+	addTaskCmd.Flags().StringP("user", "u", "", "User who is adding the task")
 
 	// deleteTaskCmd.Flags().StringVarP(&deleteTaskName, "name", "d", "", "Name of the task to delete")
 	// updateTaskCmd.Flags().StringVarP(&updateTaskName, "name", "u", "", "Name of the task to update")

--- a/controller/action.go
+++ b/controller/action.go
@@ -60,8 +60,8 @@ func DeleteTask(args []string) {
 }
 
 func AddTask(args []string) {
-	if len(args) == 0 {
-		fmt.Println("Please provide the task details")
+	if len(args) < 5 {
+		fmt.Println("Please provide the task details and user information")
 		return
 	}
 	file, records, err := db.ReadFile("workbook.xlsx", "tasks")
@@ -69,11 +69,12 @@ func AddTask(args []string) {
 		log.Fatal("error while getting file: ", err)
 	}
 	nextRow := len(records) + 1
-	err = utils.WriteInFile(file, nextRow, args)
+	task := append(args[:4], args[4])
+	err = utils.WriteInFile(file, nextRow, task)
 	if err != nil {
 		log.Fatal("Error while adding task: ", err)
 	}
-	fmt.Printf("Added task with id %s", args[0])
+	fmt.Printf("Added task with id %s by user %s", args[0], args[4])
 }
 
 func GetTasks(args []string) {

--- a/readme.md
+++ b/readme.md
@@ -34,7 +34,7 @@ A command-line interface (CLI) application built with Go and Cobra for managing 
 ### Add a Task
 To add a task, use the `add` command with the `-n` flag:
 ```sh
-go run main.go add "taskId" "taskName" "taskDesc" "taskStatus"
+go run main.go add "taskId" "taskName" "taskDesc" "taskStatus" -u "userName"
 ```
 ### Get a Task
 To get a task, use the `get` command with the `-g` flag:


### PR DESCRIPTION
Add user information to tasks.

* Modify `cmd/cmd.go` to add a flag for specifying the user who is adding the task and pass the user information to the `AddTask` function.
* Modify `controller/action.go` to take an additional argument for the user who added the task and include the user information in the task record.
* Update `readme.md` to include instructions for specifying the user when adding a task.